### PR TITLE
Add column formatting to exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ case. Example: ``name`` becomes ``Name``.
 If you want to use formatting in your columns, you can make this known to the
 exporter know this by changing the column header names. So for a bold column
 ``name``, you name the column header ``**name**``. Then ``**name**`` is renamed
-to ``name`` and every value in that column (except the column header itself) is
-made bold.
+to ``name`` and every value in that column is made bold.
 
 Currently supported formats are: ``**bold**``

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Exporter
 
-Exports python data structures to other file formats. For the time being only works
-for exporting to excel files.
+Exports python data structures to other file formats. For the time being only
+works for exporting to excel files.
 
 ## Usage
 
@@ -19,3 +19,25 @@ fields = ['id', 'name', 'surname']
 
 excel.export(data, fields, sheet_name='Export')
 ```
+
+## Formatting
+
+#### Spaces in column headers
+All underscores in the column headers are replaced by spaces. Example:
+``First_name`` becomes ``First name``.
+
+
+#### Capitalized column headers
+All column headers are capitalized. This means that every letter except the
+first is converted to lower case. The first character is converted to upper
+case. Example: ``name`` becomes ``Name``.
+
+
+#### Bold columns
+If you want to use formatting in your columns, you can make this known to the
+exporter know this by changing the column header names. So for a bold column
+``name``, you name the column header ``**name**``. Then ``**name**`` is renamed
+to ``name`` and every value in that column (except the column header itself) is
+made bold.
+
+Currently supported formats are: ``**bold**``

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description='Export python data structures to a few file formats.',
     url='https://github.com/stargazer/exporter/',
     license='WTFPL',
-    version=0.1,
+    version=0.2,
     install_requires=('tablib',),
     zip_safe=False,
     classifiers=(


### PR DESCRIPTION
- If header names are surrounded by double asterisks (`**[text]**`), the whole column is now made **bold**
- Underscores in headers are now replaced by spaces: `First_name` becomes `First name`
- Code improvements
